### PR TITLE
removed escape from double quotes

### DIFF
--- a/Nasl/NASL.tmLanguage
+++ b/Nasl/NASL.tmLanguage
@@ -48,15 +48,6 @@
 			<string>"</string>
 			<key>name</key>
 			<string>string.quoted.double.nasl</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>match</key>
-					<string>\\.</string>
-					<key>name</key>
-					<string>constant.character.escape.nasl</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
double quotes represent 'pure' strings that ignore escape characters. 
Having it included in highlighting causes erroneous behavior when dealing with strings such as:
string = var + "\";
